### PR TITLE
Add file list mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ echo 'export GOOGLE_GENAI_API_KEY=your_api_key_here' >> ~/.zshrc
 ```bash
 cxt <extensions> <directory-path> [prompt] [options]
 ```
+You can also provide a comma-separated list of file paths when no directory path is supplied:
+```bash
+cxt <file1,file2,...> [prompt] [options]
+```
 
 ### Arguments
 
@@ -69,6 +73,9 @@ cxt <extensions> <directory-path> [prompt] [options]
 ```bash
 # Basic: Swift files in current directory
 cxt swift ./
+
+# Explicit file list
+cxt ContentView.swift,README.md,Views/TableCell.swift
 
 # Multiple file types: Swift, Markdown, and JSON files
 cxt swift,md,json ~/Documents

--- a/Tests/cxtTests/IntegrationTests.swift
+++ b/Tests/cxtTests/IntegrationTests.swift
@@ -204,4 +204,33 @@ struct IntegrationTests {
         #expect(content.contains("// Mock content for src/app/page.tsx"))
         #expect(content.contains("// Mock content for src/lib/utils.ts"))
     }
+
+    @Test("File list mode processes exact files")
+    func testFileListModeProcessing() {
+        let basePath = FileManager.default.currentDirectoryPath
+        let paths = ["Package.swift", "README.md"]
+
+        let files = paths.map { path in
+            FileInfo(
+                url: URL(fileURLWithPath: basePath).appendingPathComponent(path),
+                relativePath: path
+            )
+        }
+
+        let exts = paths.map { URL(fileURLWithPath: $0).pathExtension.lowercased() }
+            .filter { !$0.isEmpty }
+        let uniqueExts = Array(Set(exts)).sorted()
+
+        let processor = FileProcessor(logger: { _ in })
+        let content = processor.generateContent(
+            files: files,
+            basePath: basePath,
+            extensions: uniqueExts
+        )
+
+        // Verify that only specified files appear in the content
+        #expect(content.contains("# Package.swift"))
+        #expect(content.contains("# README.md"))
+        #expect(!content.contains("# Sources"))
+    }
 }


### PR DESCRIPTION
## Summary
- allow invoking `cxt` with a comma-separated list of files when a directory isn't supplied
- document new file-list syntax in README
- test file-list processing logic

## Testing
- `swift test --enable-test-discovery` *(fails: Failed to clone repository https://github.com/apple/swift-argument-parser.git)*